### PR TITLE
Add CachyOS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ This package adds the support for wol again as dkms package.
 configured to `d` is fixed since kernel version 6.5.**
 
 **Version 3.0 has been successfully tested on: Debian, Ubuntu, Proxmox, Fedora,
-Arch and Suse!**
+Arch, Suse and CachyOS!**
 
-It is expected that the kernel got compiled with gcc.
+It is expected that the kernel got compiled with gcc or clang.
 As tool for initrd createion there has to be either mkinitcpio, update-initramfs
 or dracut.
 
@@ -53,7 +53,8 @@ two more examples which can be found in 'other_examples'.
 ## Compatibility
 
 alx-wol 3.0 has been tested on Debian 12 (Bookworm), Ubuntu 24.4 (Noble Numbat),
-Proxmox VE 8.3-1, Fedora 41-1.4, Arch 2025-02-01 and Suse Leap 15.6.
+Proxmox VE 8.3-1, Fedora 41-1.4, Arch 2025-02-01, Suse Leap 15.6 and
+CachyOS (kernel 7.0.9).
 
 ## How to use it
 
@@ -145,7 +146,15 @@ without a complete update in advance.
 I didn't check the regular Suse update mechanism. Please check the logs when
 Suse does a kernel update.
 
-## Ho to remove it
+### CachyOS
+
+Since CachyOS kernels are compiled with Clang, the build system
+automatically detects Clang and uses `LLVM=1 LLVM_IAS=1` during compilation.
+Install dkms, clang and lld before running the install script:
+
+`sudo pacman -S dkms clang lld`
+
+## How to remove it
 
 Calling the script `remove.sh` will remove all installed versions of
 this package from dkms. Only the installed data will be removed, the

--- a/dkms.conf
+++ b/dkms.conf
@@ -1,6 +1,15 @@
 PACKAGE_NAME="alx-wol"
 PACKAGE_VERSION="3.1"
 
+# Provide fallback for override_dest_module_location if not defined by dkms
+# This function is used by Arch-based systems to override the
+# destination module location to /updates/dkms
+if ! type override_dest_module_location >/dev/null 2>&1; then
+    override_dest_module_location() {
+        echo "$1"
+    }
+fi
+
 BUILT_MODULE_NAME[0]="alx"
 BUILT_MODULE_LOCATION[0]="alx/"
 DEST_MODULE_NAME[0]="alx"

--- a/dkms.conf
+++ b/dkms.conf
@@ -38,6 +38,18 @@ if [ "${module}" != "" ]; then
 	# get the compiler to use
 	gcc_exe="$("${select_gcc}" "${arch}" "${build}" "${gcc_used}")"
 
+	# initialise llvm flags
+	llvm_flags=""
+
+	# detect clang usage to support kernels built with clang (e.g. CachyOS)
+	if [ $? -eq 0 ]; then
+		# if compiler path contains 'clang' add LLVM flags
+		echo "${gcc_exe}" | grep -qi 'clang'
+		if [ $? -eq 0 ]; then
+			llvm_flags="LLVM=1 LLVM_IAS=1"
+		fi
+	fi
+
 	# set the make command line
-	MAKE[0]="make -C \"$kernel_source_dir\" M=\"$dkms_tree/$module/$module_version/build\" HOSTCC=\"${gcc_exe}\" CC=\"${gcc_exe}\""
+	MAKE[0]="make -C \"$kernel_source_dir\" M=\"$dkms_tree/$module/$module_version/build\" HOSTCC=\"${gcc_exe}\" CC=\"${gcc_exe}\" ${llvm_flags}"
 fi

--- a/other_examples/e1000/dkms.conf
+++ b/other_examples/e1000/dkms.conf
@@ -1,6 +1,15 @@
 PACKAGE_NAME="e1000-test"
 PACKAGE_VERSION="3.0"
 
+# Provide fallback for override_dest_module_location if not defined by dkms
+# This function is used by Arch-based systems to override the
+# destination module location to /updates/dkms
+if ! type override_dest_module_location >/dev/null 2>&1; then
+    override_dest_module_location() {
+        echo "$1"
+    }
+fi
+
 BUILT_MODULE_NAME[0]="e1000"
 BUILT_MODULE_LOCATION[0]="e1000/"
 DEST_MODULE_NAME[0]="e1000"

--- a/other_examples/e1000/dkms.conf
+++ b/other_examples/e1000/dkms.conf
@@ -47,6 +47,18 @@ if [ "${module}" != "" ]; then
 	# get the compiler to use
 	gcc_exe="$("${select_gcc}" "${arch}" "${build}" "${gcc_used}")"
 
+	# initialise llvm flags
+	llvm_flags=""
+
+	# detect clang usage to support kernels built with clang (e.g. CachyOS)
+	if [ $? -eq 0 ]; then
+		# if compiler path contains 'clang' add LLVM flags
+		echo "${gcc_exe}" | grep -qi 'clang'
+		if [ $? -eq 0 ]; then
+			llvm_flags="LLVM=1 LLVM_IAS=1"
+		fi
+	fi
+
 	# set the make command line
-	MAKE[0]="make -C \"$kernel_source_dir\" M=\"$dkms_tree/$module/$module_version/build\" HOSTCC=\"${gcc_exe}\" CC=\"${gcc_exe}\""
+	MAKE[0]="make -C \"$kernel_source_dir\" M=\"$dkms_tree/$module/$module_version/build\" HOSTCC=\"${gcc_exe}\" CC=\"${gcc_exe}\" ${llvm_flags}"
 fi

--- a/other_examples/pata/dkms.conf
+++ b/other_examples/pata/dkms.conf
@@ -1,6 +1,15 @@
 PACKAGE_NAME="pata_acpi_test"
 PACKAGE_VERSION="3.0"
 
+# Provide fallback for override_dest_module_location if not defined by dkms
+# This function is used by Arch-based systems to override the
+# destination module location to /updates/dkms
+if ! type override_dest_module_location >/dev/null 2>&1; then
+    override_dest_module_location() {
+        echo "$1"
+    }
+fi
+
 BUILT_MODULE_NAME[0]="pata_acpi"
 BUILT_MODULE_LOCATION[0]="."
 DEST_MODULE_NAME[0]="pata_acpi"

--- a/other_examples/pata/dkms.conf
+++ b/other_examples/pata/dkms.conf
@@ -47,6 +47,18 @@ if [ "${module}" != "" ]; then
 	# get the compiler to use
 	gcc_exe="$("${select_gcc}" "${arch}" "${build}" "${gcc_used}")"
 
+	# initialise llvm flags
+	llvm_flags=""
+
+	# detect clang usage to support kernels built with clang (e.g. CachyOS)
+	if [ $? -eq 0 ]; then
+		# if compiler path contains 'clang' add LLVM flags
+		echo "${gcc_exe}" | grep -qi 'clang'
+		if [ $? -eq 0 ]; then
+			llvm_flags="LLVM=1 LLVM_IAS=1"
+		fi
+	fi
+
 	# set the make command line
-	MAKE[0]="make -C \"$kernel_source_dir\" M=\"$dkms_tree/$module/$module_version/build\" HOSTCC=\"${gcc_exe}\" CC=\"${gcc_exe}\""
+	MAKE[0]="make -C \"$kernel_source_dir\" M=\"$dkms_tree/$module/$module_version/build\" HOSTCC=\"${gcc_exe}\" CC=\"${gcc_exe}\" ${llvm_flags}"
 fi

--- a/scripts/select_gcc.sh
+++ b/scripts/select_gcc.sh
@@ -24,9 +24,9 @@ truncate -s 0 "${list}.unsort"
 
 get_version ()
 {
-	# extract the version information out of 'gcc --version'
-	# take the three digit version at the end of the line
-	echo "$1" | sed -n 's|^.* \([[:digit:]]\{1,\}\.[[:digit:]]\{1,\}\.[[:digit:]]\{1,\}\).*$|\1|p'
+	# extract the version information out of 'gcc --version' or 'clang --version'
+	# accept both "X.Y.Z" and standalone "X" (e.g. clang version 17 -> 17.0.0)
+	echo "$1" | sed -n 's|^.* \([[:digit:]]\{1,\}\.[[:digit:]]\{1,\}\.[[:digit:]]\{1,\}\).*$|\1|p;t;s|^.* \([[:digit:]]\{1,\}\).*$|\1.0.0|p'
 }
 
 # ask all files which may be a gcc for the version
@@ -52,6 +52,26 @@ do
 			echo "$version ${exe}" >> "${list}.unsort"
 		fi
 	fi
+done
+
+# also check for clang executables
+# target the compiler binaries explicitly, not wrapper/format/tidy tools
+target_clang="clang clang++ clang-c clang-cl clang-*"
+for pattern in ${target_clang}; do
+	for exe in /usr/bin/${arch}${pattern} /usr/bin/${pattern}; do
+		# check for: file or symlink, executable
+		if { [ -f "${exe}" ] || [ -L "${exe}" ]; } && [ -x "${exe}" ];
+		then
+			# ask for version
+			versionstring="$(${exe} --version 2>/dev/null | \
+				grep 'clang version [0-9]')"
+			if [ "${versionstring}" != "" ];
+			then
+				version="$(get_version "${versionstring}" | sed -n 's|\.| |gp')"
+				echo "${version} ${exe}" >> "${list}.unsort"
+			fi
+		fi
+	done
 done
 
 # do the same for the compiler mentioned in the given file


### PR DESCRIPTION
My attempt to add CachyOS support out of the box.
Worked on my machine, but didn't test if it breaks compatibility with other distros.
Installation logs had 1 error and 1 warning, but still this works:

<details>
<summary>Output</summary>

```text
❯ sudo ./install.sh
[sudo] password for vlad: 
found other versions of alx-wol installed
	shall they all be removed [y/N]? y
remove alx-wol    ...

Error! Empty kernelver[0]
deinstallation of alx-wol completed
/etc/initramfs-tools/hooks doesn't exist
continue installation, update of initramfs may fail
#### using /usr/bin/clang to compile module ####
Creating symlink /var/lib/dkms/alx-wol/3.1/source -> /usr/src/alx-wol-3.1

Sign command: /usr/lib/modules/7.0.9-1-cachyos/build/scripts/sign-file
Signing key: /var/lib/dkms/mok.key
Public certificate (MOK): /var/lib/dkms/mok.pub

Running the pre_build script........ done.
Building module(s).... done.
Signing module /var/lib/dkms/alx-wol/3.1/build/alx/alx.ko
Found pre-existing /usr/lib/modules/7.0.9-1-cachyos/kernel/drivers/net/ethernet/atheros/alx/alx.ko.zst, archiving for uninstallation
Installing /usr/lib/modules/7.0.9-1-cachyos/updates/dkms/alx.ko.zst
Running the post_install script:
Building initramfs for linux-cachyos-lts (6.18.32-1-cachyos-lts)
==> Using drop-in configuration file: '10-chwd.conf'
==> Using drop-in configuration file: '10-chwd-kms.conf'
==> Using drop-in configuration file: '10-limine-snapper-sync.conf'
==> Starting build: '6.18.32-1-cachyos-lts'
  -> Running build hook: [base]
  -> Running build hook: [systemd]
  -> Running build hook: [autodetect]
  -> Running build hook: [microcode]
  -> Running build hook: [modconf]
  -> Running build hook: [block]
  -> Running build hook: [keyboard]
  -> Running build hook: [sd-vconsole]
  -> Running build hook: [plymouth]
  -> Running build hook: [filesystems]
  -> Running build hook: [sd-btrfs-overlayfs]
==> Generating module dependencies
==> Creating zstd-compressed initcpio image: '/tmp/staging_initramfs.img'
  -> Early uncompressed CPIO image generation successful
==> Initcpio image generation successful
Kernel stored in /boot/3f02fc10484f418681ffaf1a74839023/linux-cachyos-lts/vmlinuz-linux-cachyos-lts
Initramfs stored in /boot/3f02fc10484f418681ffaf1a74839023/linux-cachyos-lts/initramfs-linux-cachyos-lts
Updated: /boot/limine.conf
Building initramfs for linux-cachyos (7.0.9-1-cachyos)
==> Using drop-in configuration file: '10-chwd.conf'
==> Using drop-in configuration file: '10-chwd-kms.conf'
==> Using drop-in configuration file: '10-limine-snapper-sync.conf'
==> Starting build: '7.0.9-1-cachyos'
  -> Running build hook: [base]
  -> Running build hook: [systemd]
  -> Running build hook: [autodetect]
  -> Running build hook: [microcode]
  -> Running build hook: [modconf]
  -> Running build hook: [block]
  -> Running build hook: [keyboard]
  -> Running build hook: [sd-vconsole]
  -> Running build hook: [plymouth]
  -> Running build hook: [filesystems]
  -> Running build hook: [sd-btrfs-overlayfs]
==> Generating module dependencies
==> Creating zstd-compressed initcpio image: '/tmp/staging_initramfs.img'
  -> Early uncompressed CPIO image generation successful
==> Initcpio image generation successful
Kernel stored in /boot/3f02fc10484f418681ffaf1a74839023/linux-cachyos/vmlinuz-linux-cachyos
Initramfs stored in /boot/3f02fc10484f418681ffaf1a74839023/linux-cachyos/initramfs-linux-cachyos
Updated: /boot/limine.conf
Running depmod... done.
#### installation of alx-wol version 3.1 succeeded ####
```

</details>


Warning: Made with AI, so you may not be in a hurry to merge it.